### PR TITLE
Quickfix string conversion error 

### DIFF
--- a/Assets/Samples/1 - Chat/ChatSample.cs
+++ b/Assets/Samples/1 - Chat/ChatSample.cs
@@ -14,11 +14,13 @@ namespace Gpt4All.Samples
         public ScrollRect scroll;
         public Button submit;
 
+        private string _previousText;
+
         private void Awake()
         {
             input.onEndEdit.AddListener(OnSubmit);
             submit.onClick.AddListener(OnSubmitPressed);
-            manager.OnResponse += OnResponseHandler;
+            manager.OnResponseUpdated += OnResponseHandler;
         }
     
         private void OnSubmit(string prompt)
@@ -40,14 +42,16 @@ namespace Gpt4All.Samples
 
             input.text = "";
             output.text += $"<b>User:</b> {prompt}\n<b>Answer</b>: ";
+            _previousText = output.text;
+            
             await manager.Prompt(prompt);
             output.text += "\n";
             ScrollDown();
         }
     
-        private void OnResponseHandler(int tokenId, string response)
+        private void OnResponseHandler(string response)
         {
-            output.text += response;
+            output.text = _previousText + response;
             ScrollDown();
         }
 

--- a/Packages/com.gpt4all.unity/Scripts/LlmManager.cs
+++ b/Packages/com.gpt4all.unity/Scripts/LlmManager.cs
@@ -67,6 +67,7 @@ namespace Gpt4All
 
         public event LlmPromptDelegate OnPrompt;
         public event LlmResponseDelegate OnResponse;
+        public event LlmResponseUpdatedDelegate OnResponseUpdated;
         public event LlmRecalculateDelegate OnRecalculate;
 
         private LlmWrapper _llm;
@@ -112,6 +113,7 @@ namespace Gpt4All
                 _ctx = LlmPromptContext.GetDefaultContext();
                 _llm.OnPrompt += OnPromptHandler;
                 _llm.OnResponse += OnResponseHandler;
+                _llm.OnResponseUpdated += OnResponseUpdatedHandler;
                 _llm.OnRecalculate += OnRecalculateHandler;
             }
             catch (Exception e)
@@ -168,9 +170,14 @@ namespace Gpt4All
             _dispatcher.Execute(() => OnPrompt?.Invoke(tokenId));
         }
 
-        private void OnResponseHandler(int tokenId, string response)
+        private void OnResponseHandler(int tokenId, byte[] response)
         {
             _dispatcher.Execute(() => OnResponse?.Invoke(tokenId, response));
+        }
+        
+        private void OnResponseUpdatedHandler(string response)
+        {
+            _dispatcher.Execute(() => OnResponseUpdated?.Invoke(response));
         }
 
         private void OnRecalculateHandler(bool isRecalculating)

--- a/Packages/com.gpt4all.unity/Scripts/Native/LlmNative.cs
+++ b/Packages/com.gpt4all.unity/Scripts/Native/LlmNative.cs
@@ -36,7 +36,7 @@ namespace Gpt4All.Native
     public delegate bool llmodel_prompt_callback(int token_id);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public delegate bool llmodel_response_callback(int token_id, string response);
+    public delegate bool llmodel_response_callback(int token_id, IntPtr response);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate bool llmodel_recalculate_callback(bool is_recalculating);

--- a/Packages/com.gpt4all.unity/Scripts/Utils/TextUtils.cs
+++ b/Packages/com.gpt4all.unity/Scripts/Utils/TextUtils.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Gpt4All.Utils
+{
+    public static class TextUtils
+    {
+        /// <summary>
+        /// Copy null-terminated Utf8 string from native memory to managed byte buffer.
+        /// </summary>
+        public static byte[] BytesFromNativeUtf8(IntPtr nativeUtf8)
+        {
+            // check input null
+            if (nativeUtf8 == IntPtr.Zero)
+                return null;
+
+            // find null terminator
+            var len = 0;
+            while (Marshal.ReadByte(nativeUtf8, len) != 0) ++len;
+
+            // check empty string
+            if (len == 0)
+                return Array.Empty<byte>();
+
+            var buffer = new byte[len];
+            Marshal.Copy(nativeUtf8, buffer, 0, buffer.Length);
+            return buffer;
+        }
+
+    }
+}

--- a/Packages/com.gpt4all.unity/Scripts/Utils/TextUtils.cs.meta
+++ b/Packages/com.gpt4all.unity/Scripts/Utils/TextUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ef433a2c58840caabd7cf158399048f
+timeCreated: 1687251007


### PR DESCRIPTION
Adresses #7 

If LLM model would output non-ascii character, it would usually result error like:
```
ExecutionEngineException: String conversion error: Partial byte sequence encountered in the input.
```

At first I tried to fix it by just converting tokens string by custom code. But result looked like this:
```
<b>User:</b> Расскажи шутку?
<b>Answer</b>: ��а, ��ульон ��ыстрелива��д��я.
```

It turned out that LLM can return not one token, but divide one unicode character to several tokens. I bandaid that with updating all string each time new token appears. It isn't great, but works for now. 